### PR TITLE
Simplify scrollToElement to use scrollIntoView

### DIFF
--- a/src/utils/scrollTo.ts
+++ b/src/utils/scrollTo.ts
@@ -1,60 +1,8 @@
-// help functions
-const easeInOutQuad = (t: number, b: number, c: number, d: number): number => {
-  t /= d / 2
-  if (t < 1) return c / 2 * t * t + b
-  t--
-  return -c / 2 * (t * (t - 2) - 1) + b
-}
-
-const animatedScrollTo = (
-  element: HTMLElement,
-  to: number,
-  duration: number,
-  callback?: () => void
-): void => {
-  let start = element.scrollTop
-  let change = to - start
-  let animationStart = +new Date()
-  let animating = true
-  let lastpos: number | null = null
-
-  const animateScroll = (): void => {
-    if (!animating) {
-      return
-    }
-    requestAnimationFrame(animateScroll)
-    const now = +new Date()
-    const val = Math.floor(easeInOutQuad(now - animationStart, start, change, duration))
-    if (lastpos) {
-      if (lastpos === Math.ceil(element.scrollTop)) {
-        lastpos = val
-        element.scrollTop = val
-      } else {
-        animating = false
-      }
-    } else {
-      lastpos = val
-      element.scrollTop = val
-    }
-    if (now > animationStart + duration) {
-      element.scrollTop = to
-      animating = false
-      if (callback) {
-        callback()
-      }
-    }
-  }
-  requestAnimationFrame(animateScroll)
-}
-
 const scrollToElement = (selector: string): void => {
   // Scroll to search highlight word
-  const container = document.documentElement
   const anchor = document.querySelector(selector)
   if (anchor) {
-    const { y } = anchor.getBoundingClientRect()
-    const DURATION = 300
-    animatedScrollTo(container, container.scrollTop + y - 60, DURATION)
+    anchor.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
 }
 


### PR DESCRIPTION
Got a bit annoyed that the anchors didn't scroll down to the specific content - this PR should fix that.
Cheers,
Rasmus